### PR TITLE
Fixing DonorDrive Avatar URL

### DIFF
--- a/StreamUP DLL/EventTriggerExtensions.cs
+++ b/StreamUP DLL/EventTriggerExtensions.cs
@@ -228,7 +228,6 @@ namespace StreamUP {
                     triggerData.Donation = true;
                     triggerData.User = sbArgs["donorName"].ToString();
                     triggerData.Message = sbArgs["donorMessage"].ToString();
-                    triggerData.UserImage = sbArgs["donorAvatarUrl"].ToString();
                     if (productSettings.ContainsKey("LocalCurrencyCode"))
                     {
                         amount = decimal.Parse(sbArgs["amount"].ToString());
@@ -241,6 +240,10 @@ namespace StreamUP {
                             triggerData.AmountCurrencyDouble = amountCurrencyDouble;
                         }                     
                     }
+
+                    string donorAvatarUrl = CPH.TryGetArg("donorAvatarUrl",out string donorAvatarUrlInput) ? donorAvatarUrlInput : "https://static.donordrive.com/clients/try/img/avatar-constituent-default.gif";
+                    triggerData.UserImage = donorAvatarUrl;
+                    
                     break;
                 // TWITCH
                 case EventType.TwitchAnnouncement:

--- a/StreamUP DLL/Properties/AssemblyInfo.cs
+++ b/StreamUP DLL/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Build Number
 //      Revision
-[assembly: AssemblyVersion("1.0.11.10")]
-[assembly: AssemblyFileVersion("1.0.11.10")]
+[assembly: AssemblyVersion("1.0.11.11")]
+[assembly: AssemblyFileVersion("1.0.11.11")]


### PR DESCRIPTION
test data is empty, so we do a check for it now, if its not there use their default one.